### PR TITLE
Use default path and filename instead of raise errors

### DIFF
--- a/lib/do_it/commfig.ex
+++ b/lib/do_it/commfig.ex
@@ -12,7 +12,7 @@ defmodule DoIt.Commfig do
   end
 
   @spec start_link([...]) :: :ignore | {:error, any()} | {:ok, pid()}
-  def start_link([dirname, filename] = args) do
+  def start_link([dirname, filename] = _args) do
     case {dirname, filename} do
       {nil, nil} ->
         do_start(System.tmp_dir(), @default_app_name)

--- a/lib/do_it/commfig.ex
+++ b/lib/do_it/commfig.ex
@@ -21,7 +21,6 @@ defmodule DoIt.Commfig do
         do_start(System.tmp_dir(), filename)
 
       {dirname, nil} ->
-        IO.inspect(args, label: "{dirname, nil}")
         do_start(dirname, @default_app_name)
 
       {dirname, filename} ->

--- a/lib/do_it/commfig.ex
+++ b/lib/do_it/commfig.ex
@@ -11,28 +11,28 @@ defmodule DoIt.Commfig do
     defstruct [:dir, :file, :data]
   end
 
-  def start_link([dirname, filename]) when is_nil(dirname) or is_nil(filename),
-    do: start_link([System.tmp_dir(), @default_app_name])
+  def start_link([dirname, filename] = args) do
+    case {dirname, filename} do
+      {nil, nil} ->
+        IO.inspect(args, label: "{nil, nil}")
+        GenServer.start_link(__MODULE__, [System.tmp_dir(), @default_app_name], name: __MODULE__)
 
-  def start_link([dirname, filename]) do
-    GenServer.start_link(__MODULE__, [dirname, filename], name: __MODULE__)
+      {nil, filename} ->
+        IO.inspect(args, label: "{nil, filename}")
+        GenServer.start_link(__MODULE__, [System.tmp_dir(), filename], name: __MODULE__)
+
+      {dirname, nil} ->
+        IO.inspect(args, label: "{dirname, nil}")
+        GenServer.start_link(__MODULE__, [dirname, @default_app_name], name: __MODULE__)
+
+      _ ->
+        raise(
+          DoIt.InitConfigError,
+          message:
+            "dirname and filename are required for the initialization of the persistent configuration"
+        )
+    end
   end
-
-  def start_link(_),
-    do:
-      raise(
-        DoIt.InitConfigError,
-        message:
-          "dirname and filename are required for the initialization of the persistent configuration"
-      )
-
-  def start_link(),
-    do:
-      raise(
-        DoIt.InitConfigError,
-        message:
-          "dirname and filename are required for the initialization of the persistent configuration"
-      )
 
   def get_dir() do
     GenServer.call(__MODULE__, :get_dir)

--- a/lib/do_it/commfig.ex
+++ b/lib/do_it/commfig.ex
@@ -3,7 +3,8 @@ defmodule DoIt.Commfig do
   use GenServer
   require Logger
 
-  @default_app_name ".do_it.json"
+  @default_app_name Mix.Project.config()[:app]
+                    |> Atom.to_string()
 
   defmodule State do
     @moduledoc false

--- a/lib/do_it/commfig.ex
+++ b/lib/do_it/commfig.ex
@@ -11,27 +11,42 @@ defmodule DoIt.Commfig do
     defstruct [:dir, :file, :data]
   end
 
+  @spec start_link([...]) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link([dirname, filename] = args) do
     case {dirname, filename} do
       {nil, nil} ->
-        IO.inspect(args, label: "{nil, nil}")
-        GenServer.start_link(__MODULE__, [System.tmp_dir(), @default_app_name], name: __MODULE__)
+        do_start(System.tmp_dir(), @default_app_name)
 
       {nil, filename} ->
-        IO.inspect(args, label: "{nil, filename}")
-        GenServer.start_link(__MODULE__, [System.tmp_dir(), filename], name: __MODULE__)
+        do_start(System.tmp_dir(), filename)
 
       {dirname, nil} ->
         IO.inspect(args, label: "{dirname, nil}")
-        GenServer.start_link(__MODULE__, [dirname, @default_app_name], name: __MODULE__)
+        do_start(dirname, @default_app_name)
 
-      _ ->
-        raise(
-          DoIt.InitConfigError,
-          message:
-            "dirname and filename are required for the initialization of the persistent configuration"
-        )
+      {dirname, filename} ->
+        do_start(dirname, filename)
     end
+  end
+
+  def start_link(_),
+    do:
+      raise(
+        DoIt.InitConfigError,
+        message:
+          "dirname and filename are required for the initialization of the persistent configuration"
+      )
+
+  def start_link(),
+    do:
+      raise(
+        DoIt.InitConfigError,
+        message:
+          "dirname and filename are required for the initialization of the persistent configuration"
+      )
+
+  defp do_start(dirname, filename) do
+    GenServer.start_link(__MODULE__, [dirname, filename], name: __MODULE__)
   end
 
   def get_dir() do

--- a/lib/do_it/commfig.ex
+++ b/lib/do_it/commfig.ex
@@ -3,30 +3,15 @@ defmodule DoIt.Commfig do
   use GenServer
   require Logger
 
+  @default_app_name ".do_it.json"
+
   defmodule State do
     @moduledoc false
     defstruct [:dir, :file, :data]
   end
 
-  def start_link([dirname, filename]) when is_nil(dirname) or is_nil(filename) do
-    case {dirname, filename} do
-      {nil, nil} ->
-        raise(DoIt.InitConfigError,
-          message:
-            "dirname and filename are required for the initialization of the persistent configuration"
-        )
-
-      {nil, _} ->
-        raise(DoIt.InitConfigError,
-          message: "dirname is required for the initialization of the persistent configuration"
-        )
-
-      {_, nil} ->
-        raise(DoIt.InitConfigError,
-          message: "filename is required for the initialization of the persistent configuration"
-        )
-    end
-  end
+  def start_link([dirname, filename]) when is_nil(dirname) or is_nil(filename),
+    do: start_link([System.tmp_dir(), @default_app_name])
 
   def start_link([dirname, filename]) do
     GenServer.start_link(__MODULE__, [dirname, filename], name: __MODULE__)


### PR DESCRIPTION
First of all great job with this library!
This PR aims to avoid runtime errors if the user has not defined a persistent configuration file path.